### PR TITLE
Add fetch depth for release workflow

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -34,6 +34,8 @@ jobs:
         go-version: 1.14.x
     - name: checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What 

As the title says, I added `fetch-depth` argument for the release workflow's checkout action.

## Why

Because the default behavior, the `fetch-depth` only gets the `depth` of `1`. 
That's why the release comments only contain on commit.

👇 It only contains one commit

![image](https://user-images.githubusercontent.com/23056537/106444316-eeedea80-64c0-11eb-9325-d5840fd3e1c1.png)

 I want to improve the release flow because it's better to know the changes by this page.