### PR TITLE
fix folder prefix filter using library

### DIFF
--- a/assets/info.plist
+++ b/assets/info.plist
@@ -160,7 +160,7 @@
 		</dict>
 	</dict>
 	<key>version</key>
-	<string>v0.3.1</string>
+	<string>v0.4.0</string>
 	<key>webaddress</key>
 	<string>https://github.com/konoui/alfred-bookmarks</string>
 </dict>

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -89,13 +89,13 @@ func TestRun(t *testing.T) {
 			filepath: filepath.Join(testdataPath, "empty-results.json"),
 		},
 		{
-			name: "fildter by folder name. return firefox when RemoveDuplicate is true",
+			name: "filter by folder name from all bookmarks. return firefox",
 			args: args{
 				query:  "",
 				folder: "Bookmark Menu",
 			},
 			config: &Config{
-				RemoveDuplicates: true,
+				RemoveDuplicates: false,
 				MaxCacheAge:      -1,
 				Firefox: Firefox{
 					Enable:      true,
@@ -129,9 +129,9 @@ func TestRun(t *testing.T) {
 			awf.SetEmptyWarning(emptyTitle, emptySubtitle)
 
 			r := &runtime{
-				cfg:          tt.config,
-				query:        tt.args.query,
-				folderPrefix: tt.args.folder,
+				cfg:           tt.config,
+				query:         tt.args.query,
+				folderPrefixF: filterBySubtitle(tt.args.folder),
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 
 			got := outBuf.Bytes()
 			if diff := alfred.DiffOutput(want, got); diff != "" {
-				t.Errorf("+want -got\n%+v", diff)
+				t.Errorf("-want +got\n%+v", diff)
 			}
 
 			// automatically update test data

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/frioux/leatherman v0.0.0-20200721002700-06899856e483
 	github.com/google/go-cmp v0.5.2
-	github.com/konoui/go-alfred v0.10.0
+	github.com/konoui/go-alfred v0.11.0
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konoui/go-alfred v0.10.0 h1:F7k1kfDiQ23Pnr+6TOBLrOkNnCl7PauwnLtVr+lptB4=
-github.com/konoui/go-alfred v0.10.0/go.mod h1:S2ZhSnr3TIWBOvi3NeDhFrT0WV4867t6GSYklWznmtA=
+github.com/konoui/go-alfred v0.11.0 h1:jmePQ1uwrgLGeTKRvxmwSsEzZcbOl3A6TCzPeBbqju0=
+github.com/konoui/go-alfred v0.11.0/go.mod h1:S2ZhSnr3TIWBOvi3NeDhFrT0WV4867t6GSYklWznmtA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/pkg/bookmarker/bookmark.go
+++ b/pkg/bookmarker/bookmark.go
@@ -2,7 +2,6 @@ package bookmarker
 
 import (
 	"sort"
-	"strings"
 )
 
 // bookmarkerName is a type of supported browser name
@@ -59,34 +58,4 @@ func (b Bookmarks) uniqByURI() (uniq Bookmarks) {
 	}
 
 	return
-}
-
-func (b Bookmarks) filterByFolderPrefix(query string) (fb Bookmarks) {
-	if query == "" {
-		return b
-	}
-
-	for _, e := range b {
-		if hasFolderPrefix(e.Folder, query) {
-			fb = append(fb, e)
-		}
-	}
-
-	return
-}
-
-func hasFolderPrefix(folder, prefix string) bool {
-	folder = strings.ToLower(folder)
-	folder = strings.ReplaceAll(folder, " ", "")
-	prefix = strings.ToLower(prefix)
-	prefix = strings.ReplaceAll(prefix, " ", "")
-	if !strings.HasPrefix(prefix, "/") {
-		prefix = "/" + prefix
-	}
-
-	if strings.HasPrefix(folder, prefix) {
-		return true
-	}
-
-	return strings.HasPrefix(folder+"/", prefix)
 }

--- a/pkg/bookmarker/bookmark_test.go
+++ b/pkg/bookmarker/bookmark_test.go
@@ -44,50 +44,6 @@ func TestBookmarks_UniqByURI(t *testing.T) {
 	}
 }
 
-func TestBookmarks_FilterByFolderPrefix(t *testing.T) {
-	type args struct {
-		query string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		options []Option
-		want    Bookmarks
-	}{
-		{
-			name: "if empty string, return all bookmarks",
-			want: testChromeBookmarks,
-			options: []Option{
-				OptionChrome(defaultChromeProfilePath, testProfile),
-			},
-			args: args{
-				query: "",
-			},
-		},
-		{
-			name: "filter by folder prefix with chrome folder name",
-			want: testChromeBookmarks,
-			options: []Option{
-				OptionFirefox(defaultFirefoxProfilePath, testProfile),
-				OptionChrome(defaultChromeProfilePath, testProfile),
-				OptionSafari(),
-			},
-			args: args{
-				query: "Bookmarks bar",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := getTestBookmarks(t, tt.options...)
-			got := b.filterByFolderPrefix(tt.args.query)
-			if diff := DiffBookmark(got, tt.want); diff != "" {
-				t.Errorf("+want/-got: %s", diff)
-			}
-		})
-	}
-}
-
 func getTestBookmarks(t *testing.T, opts ...Option) Bookmarks {
 	bookmarer, err := New(opts...)
 	if err != nil {

--- a/pkg/bookmarker/maneger.go
+++ b/pkg/bookmarker/maneger.go
@@ -6,7 +6,6 @@ import "fmt"
 type Manager struct {
 	bookmarkers      map[bookmarkerName]Bookmarker
 	removeDuplicates bool
-	folderQuery      string
 }
 
 // Option is the type to replace default parameters.
@@ -59,14 +58,6 @@ func OptionRemoveDuplicates() Option {
 	}
 }
 
-// OptionFilterByFolder filter by bookmark folder name
-func OptionFilterByFolder(folderQuery string) Option {
-	return func(m *Manager) error {
-		m.folderQuery = folderQuery
-		return nil
-	}
-}
-
 // New is a managed bookmarker to get each bookmarks
 func New(opts ...Option) (Bookmarker, error) {
 	m := &Manager{
@@ -101,12 +92,6 @@ func (m *Manager) Bookmarks() (Bookmarks, error) {
 			return bookmarks, fmt.Errorf("failed to load bookmarks in %s: %w", name, err)
 		}
 		bookmarks = append(bookmarks, b...)
-	}
-
-	// TODO folder filter should implement in each bookmark for performance
-	// But there are caching problem. the workflow uses alfred library caching
-	if q := m.folderQuery; q != "" {
-		bookmarks = bookmarks.filterByFolderPrefix(q)
 	}
 
 	// Note: execute uniq after folder filter


### PR DESCRIPTION
Folder filter was implemented in bookmark library before.
However, as cmd uses cache util of alfred library, there were cases that cmd will return cache value with query of bookmark name if folder query was specified.

repro steps.
1. `bs github` returns query bookmarks related github  and store results of query into cache file.
2. `bs -f <folder-prefix> github` ignores `<folder-prefix>` because cmd returns cache data directly. 
cached items are not filtered by `<folder-prefix>`. Folder filter is only invoked when bookmarks were loaded. 
